### PR TITLE
chore: add test and code style badges, update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Comprehensive test coverage for Stock client (9 tests, 100% coverage)
+- Comprehensive test coverage for Speedtest client (12 tests, 100% coverage)
+
+### Changed
+- Test coverage increased from 40.64% to 43.89%
+- Total test count increased from 72 to 93 tests
+
 ## [0.5.0] - 2025-11-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Samsung Frame TV Signage
 
 [![CI](https://github.com/simonpo/signage/actions/workflows/ci.yml/badge.svg)](https://github.com/simonpo/signage/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-93%20passing-success)](https://github.com/simonpo/signage/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/simonpo/signage/branch/main/graph/badge.svg)](https://codecov.io/gh/simonpo/signage)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 


### PR DESCRIPTION
## Summary
Adds additional status badges to README and updates CHANGELOG with recent test improvements.

## Changes

### Badges Added
- **Tests**: Shows 93 passing tests (links to CI workflow)
- **Code style**: Black formatter badge (links to black repo)

Current badge lineup:
- ✅ CI build status
- ✅ Tests passing (93)
- ✅ Code coverage (43.89%)
- ✅ Code style (black)
- ✅ License (MIT)
- ✅ Python version (3.9+)

### CHANGELOG Updates
Added to `[Unreleased]` section:
- Stock client test coverage (9 tests, 100%)
- Speedtest client test coverage (12 tests, 100%)
- Coverage increase: 40.64% → 43.89%
- Test count increase: 72 → 93

## Preview
Badges will appear at the top of README, providing quick visibility into:
- Build health (CI passing)
- Test status (93 passing)
- Code quality (43.89% coverage, black formatted)
- Project metadata (MIT, Python 3.9+)

## Testing
Pre-commit hooks passed (markdown files skip black/ruff/mypy)