### PR TITLE
fix: pass Codecov token correctly to codecov-action v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   config-validation:
     name: Config Validation


### PR DESCRIPTION
## Problem
Codecov upload was failing with:
```
error - Commit creating failed: {"message":"Token required - not valid tokenless upload"}
```

## Root Cause
The codecov-action v4 expects the token in `with.token`, not in `env.CODECOV_TOKEN`.

## Changes
- Move `CODECOV_TOKEN` from `env` to `with.token` parameter
- Change `file` to `files` parameter (v4 syntax)

## Testing
This will be validated when CI runs on this PR and successfully uploads coverage to Codecov.

## References
- [Codecov Action v4 docs](https://github.com/codecov/codecov-action#usage)