### PR TITLE
ci: disable automatic release trigger temporarily

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
## Problem

The release workflow has been failing repeatedly, creating noise in the workflow history. Each push to main triggers a failed release.

## Solution

**Temporarily disable the automatic push trigger** and keep only manual workflow_dispatch.

This allows us to:
1. Merge this PR without triggering another failed release
2. Manually test the release workflow to diagnose the issue
3. Re-enable auto-trigger once we confirm it works

## Next Steps

After merge:
1. Manually trigger release workflow via GitHub UI
2. Debug any remaining permission issues
3. Once successful, re-enable push trigger in a follow-up PR

## Impact

- No automatic releases on push to main (manual only)
- Prevents failed workflow runs from cluttering history
- Can still trigger releases manually when needed